### PR TITLE
feat: Add unit tests for services, use cases, and domain models

### DIFF
--- a/tests/unit/application/use-cases/offer.use-cases.spec.ts
+++ b/tests/unit/application/use-cases/offer.use-cases.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OfferUseCases } from 'src/application/use-cases/offer.use-cases';
+import { OfferService } from 'src/domain/services/offer.service';
+import { Offer } from 'src/domain/models/offer/offer';
+import { OfferType } from 'src/domain/enums/offer-type';
+import { Price } from 'src/domain/models/price';
+import { OfferStatus } from 'src/domain/enums/offer-status';
+import { Seller } from 'src/domain/models/offer/seller';
+
+describe('OfferUseCases', () => {
+  let useCases: OfferUseCases;
+  let service: OfferService;
+
+  let mockOfferService;
+
+  const mockSeller = new Seller(1, 'Test Seller', 5, true);
+
+  const offerFactory = (productId: number, offerType: OfferType, amount: number) => {
+    const price = new Price('USD', amount);
+    return new Offer(
+        price,
+        price,
+        null,
+        null,
+        null,
+        new Date(),
+        OfferStatus.ENABLE,
+        10,
+        offerType,
+        [],
+        mockSeller,
+        productId,
+    );
+  }
+
+  beforeEach(async () => {
+    mockOfferService = {
+        getOffersByProductIdAndOfferTypes: jest.fn(),
+        getAllOffersByProductId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OfferUseCases,
+        {
+          provide: OfferService,
+          useValue: mockOfferService,
+        },
+      ],
+    }).compile();
+
+    useCases = module.get<OfferUseCases>(OfferUseCases);
+    service = module.get<OfferService>(OfferService);
+  });
+
+  it('should be defined', () => {
+    expect(useCases).toBeDefined();
+  });
+
+  describe('getOffersByProductIdAndOfferTypes', () => {
+    it('should call getOffersByProductIdAndOfferTypes from service when offerTypes are provided', async () => {
+      const productId = 1;
+      const offerTypes = [OfferType.BEST_PRICE];
+      const offers = [offerFactory(productId, OfferType.BEST_PRICE, 100)];
+      mockOfferService.getOffersByProductIdAndOfferTypes.mockResolvedValue(offers);
+
+      const result = await useCases.getOffersByProductIdAndOfferTypes(productId, offerTypes);
+
+      expect(result).toEqual(offers);
+      expect(service.getOffersByProductIdAndOfferTypes).toHaveBeenCalledWith(productId, offerTypes, undefined);
+      expect(service.getAllOffersByProductId).not.toHaveBeenCalled();
+    });
+
+    it('should call getAllOffersByProductId from service when offerTypes are not provided', async () => {
+        const productId = 1;
+        const offers = [offerFactory(productId, OfferType.BEST_PRICE, 100)];
+        mockOfferService.getAllOffersByProductId.mockResolvedValue(offers);
+
+        const result = await useCases.getOffersByProductIdAndOfferTypes(productId, []);
+
+        expect(result).toEqual(offers);
+        expect(service.getAllOffersByProductId).toHaveBeenCalledWith(productId, undefined);
+        expect(service.getOffersByProductIdAndOfferTypes).not.toHaveBeenCalled();
+      });
+  });
+});

--- a/tests/unit/application/use-cases/product.use-cases.spec.ts
+++ b/tests/unit/application/use-cases/product.use-cases.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductUseCases } from 'src/application/use-cases/product.use-cases';
+import { ProductService } from 'src/domain/services/product.service';
+import { OfferService } from 'src/domain/services/offer.service';
+import { Product } from 'src/domain/models/product/product';
+import { Offer } from 'src/domain/models/offer/offer';
+import { Price } from 'src/domain/models/price';
+import { OfferStatus } from 'src/domain/enums/offer-status';
+import { Seller } from 'src/domain/models/offer/seller';
+import { OfferType } from 'src/domain/enums/offer-type';
+
+describe('ProductUseCases', () => {
+  let useCases: ProductUseCases;
+  let productService: ProductService;
+  let offerService: OfferService;
+
+  let mockProductService;
+  let mockOfferService;
+
+  const mockSeller = new Seller(1, 'Test Seller', 5, true);
+
+  const productFactory = (id: number, name: string) => {
+    return new Product(
+      id,
+      name,
+      'description',
+      [],
+      'new',
+      true,
+      new Date(),
+      'active',
+      5,
+      [],
+      [],
+      [],
+      undefined,
+      undefined
+    );
+  };
+
+  const offerFactory = (productId: number, offerType: OfferType, amount: number) => {
+    const price = new Price('USD', amount);
+    return new Offer(
+        price,
+        price,
+        null,
+        null,
+        null,
+        new Date(),
+        OfferStatus.ENABLE,
+        10,
+        offerType,
+        [],
+        mockSeller,
+        productId,
+    );
+  }
+
+  beforeEach(async () => {
+    mockProductService = {
+      getProductById: jest.fn(),
+      getRelatedProductsByCategoriesAndLimit: jest.fn(),
+    };
+    mockOfferService = {
+      getBestPricedOfferByProductId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductUseCases,
+        { provide: ProductService, useValue: mockProductService },
+        { provide: OfferService, useValue: mockOfferService },
+      ],
+    }).compile();
+
+    useCases = module.get<ProductUseCases>(ProductUseCases);
+    productService = module.get<ProductService>(ProductService);
+    offerService = module.get<OfferService>(OfferService);
+  });
+
+  it('should be defined', () => {
+    expect(useCases).toBeDefined();
+  });
+
+  describe('getProductById', () => {
+    it('should call getProductById from product service', async () => {
+      const productId = 1;
+      const product = productFactory(productId, 'Test Product');
+      mockProductService.getProductById.mockResolvedValue(product);
+
+      const result = await useCases.getProductById(productId);
+
+      expect(result).toEqual(product);
+      expect(productService.getProductById).toHaveBeenCalledWith(productId);
+    });
+  });
+
+  describe('getRelatedProductsByIdAndLimit', () => {
+    it('should return related products with their best offers', async () => {
+      const productId = 1;
+      const limit = 5;
+      const product = productFactory(productId, 'Test Product');
+      const relatedProducts = [
+        productFactory(2, 'Related Product 1'),
+        productFactory(3, 'Related Product 2'),
+      ];
+      const bestOffer1 = offerFactory(2, OfferType.BEST_PRICE, 100);
+      const bestOffer2 = offerFactory(3, OfferType.BEST_PRICE, 120);
+
+      mockProductService.getProductById.mockResolvedValue(product);
+      mockProductService.getRelatedProductsByCategoriesAndLimit.mockResolvedValue(relatedProducts);
+      mockOfferService.getBestPricedOfferByProductId.mockImplementation((id) => {
+        if (id === 2) return Promise.resolve(bestOffer1);
+        if (id === 3) return Promise.resolve(bestOffer2);
+        return Promise.resolve(null);
+      });
+
+      const result = await useCases.getRelatedProductsByIdAndLimit(productId, limit);
+
+      expect(productService.getProductById).toHaveBeenCalledWith(productId);
+      expect(productService.getRelatedProductsByCategoriesAndLimit).toHaveBeenCalledWith(product.categories, productId, limit);
+      expect(offerService.getBestPricedOfferByProductId).toHaveBeenCalledWith(2);
+      expect(offerService.getBestPricedOfferByProductId).toHaveBeenCalledWith(3);
+      expect(result[0].bestOffer).toEqual(bestOffer1);
+      expect(result[1].bestOffer).toEqual(bestOffer2);
+    });
+  });
+});

--- a/tests/unit/application/use-cases/review.use-cases.spec.ts
+++ b/tests/unit/application/use-cases/review.use-cases.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReviewUseCases } from 'src/application/use-cases/review.use-cases';
+import { ReviewService } from 'src/domain/services/review.service';
+import { Review } from 'src/domain/models/review/review';
+
+describe('ReviewUseCases', () => {
+  let useCases: ReviewUseCases;
+  let service: ReviewService;
+
+  let mockReviewService;
+
+  const reviewFactory = (id: number, productId: number) => {
+    return new Review(
+      id,
+      5,
+      'Test review',
+      new Date(),
+      [],
+      productId
+    );
+  };
+
+  beforeEach(async () => {
+    mockReviewService = {
+      getReviewsByProductId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReviewUseCases,
+        { provide: ReviewService, useValue: mockReviewService },
+      ],
+    }).compile();
+
+    useCases = module.get<ReviewUseCases>(ReviewUseCases);
+    service = module.get<ReviewService>(ReviewService);
+  });
+
+  it('should be defined', () => {
+    expect(useCases).toBeDefined();
+  });
+
+  describe('getReviewsByProductId', () => {
+    it('should call getReviewsByProductId from review service', async () => {
+      const productId = 1;
+      const reviews = [
+        reviewFactory(1, productId),
+        reviewFactory(2, productId),
+      ];
+      mockReviewService.getReviewsByProductId.mockResolvedValue(reviews);
+
+      const result = await useCases.getReviewsByProductId(productId);
+
+      expect(result).toEqual(reviews);
+      expect(service.getReviewsByProductId).toHaveBeenCalledWith(productId);
+    });
+  });
+});

--- a/tests/unit/domain/models/offer/offer.spec.ts
+++ b/tests/unit/domain/models/offer/offer.spec.ts
@@ -1,0 +1,94 @@
+import { Offer } from 'src/domain/models/offer/offer';
+import { Price } from 'src/domain/models/price';
+import { OfferStatus } from 'src/domain/enums/offer-status';
+import { OfferType } from 'src/domain/enums/offer-type';
+import { Seller } from 'src/domain/models/offer/seller';
+import { InsufficientStockException } from 'src/domain/exceptions/InsufficientStockException';
+import { IVA_RATE } from 'src/domain/constants/taxes.constants';
+
+describe('Offer', () => {
+  let offer: Offer;
+  const mockSeller = new Seller(1, 'Test Seller', 5, true);
+  const basePrice = new Price('USD', 100);
+
+  beforeEach(() => {
+    offer = new Offer(
+      basePrice,
+      new Price('USD', basePrice.amount / (1 + IVA_RATE)),
+      null,
+      null,
+      null,
+      new Date(),
+      OfferStatus.ENABLE,
+      10,
+      OfferType.BEST_PRICE,
+      [],
+      mockSeller,
+      1,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(offer).toBeDefined();
+  });
+
+  describe('calculateDiscountedPrice', () => {
+    it('should calculate the discounted price correctly', () => {
+      const discountValue = 0.2; // 20%
+      offer.calculateDiscountedPrice(discountValue);
+      expect(offer.discountedPrice).toBeDefined();
+      expect(offer.discountedPrice!.amount).toBe(basePrice.amount * (1 - discountValue));
+    });
+  });
+
+  describe('calculatePriceWithoutTaxes', () => {
+    it('should calculate price without taxes from base price if no discount', () => {
+      offer.calculatePriceWithoutTaxes();
+      expect(offer.priceWithoutTaxes.amount).toBeCloseTo(basePrice.amount / (1 + IVA_RATE));
+    });
+
+    it('should calculate price without taxes from discounted price if discount exists', () => {
+      const discountValue = 0.2; // 20%
+      offer.calculateDiscountedPrice(discountValue);
+      offer.calculatePriceWithoutTaxes();
+      expect(offer.discountedPrice).toBeDefined();
+      expect(offer.priceWithoutTaxes.amount).toBeCloseTo(offer.discountedPrice!.amount / (1 + IVA_RATE));
+    });
+  });
+
+  describe('incrementAvailableStock', () => {
+    it('should increment the available stock', () => {
+      const initialStock = offer.availableStock;
+      const quantity = 5;
+      offer.incrementAvailableStock(quantity);
+      expect(offer.availableStock).toBe(initialStock + quantity);
+    });
+  });
+
+  describe('decrementAvailableStock', () => {
+    it('should decrement the available stock', () => {
+      const initialStock = offer.availableStock;
+      const quantity = 5;
+      offer.decrementAvailableStock(quantity);
+      expect(offer.availableStock).toBe(initialStock - quantity);
+    });
+
+    it('should throw InsufficientStockException if stock is not enough', () => {
+      const quantity = offer.availableStock + 1;
+      expect(() => offer.decrementAvailableStock(quantity)).toThrow(InsufficientStockException);
+    });
+  });
+
+  describe('calculateInstallmentPlan', () => {
+    it('should calculate the installment plan correctly', () => {
+      const numberOfInstallments = 12;
+      const interestRate = 0.1; // 10%
+      offer.calculateInstallmentPlan(numberOfInstallments, interestRate);
+      expect(offer.installmentPlan).toBeDefined();
+      expect(offer.installmentPlan!.numberOfInstallments).toBe(numberOfInstallments);
+      expect(offer.installmentPlan!.interestRate).toBe(interestRate);
+      const expectedInstallmentAmount = (basePrice.amount / numberOfInstallments) * (1 + interestRate);
+      expect(offer.installmentPlan!.installmentAmount.amount).toBeCloseTo(expectedInstallmentAmount);
+    });
+  });
+});

--- a/tests/unit/domain/models/product/product.spec.ts
+++ b/tests/unit/domain/models/product/product.spec.ts
@@ -1,0 +1,84 @@
+import { Product } from 'src/domain/models/product/product';
+import { Offer } from 'src/domain/models/offer/offer';
+import { Review } from 'src/domain/models/review/review';
+import { OfferNotFoundException } from 'src/domain/exceptions/OfferNotFoundException';
+import { Price } from 'src/domain/models/price';
+import { OfferStatus } from 'src/domain/enums/offer-status';
+import { OfferType } from 'src/domain/enums/offer-type';
+import { Seller } from 'src/domain/models/offer/seller';
+
+describe('Product', () => {
+  let product: Product;
+  const mockSeller = new Seller(1, 'Test Seller', 5, true);
+
+  const offerFactory = (productId: number, offerType: OfferType, amount: number) => {
+    const price = new Price('USD', amount);
+    return new Offer(
+        price,
+        price,
+        null,
+        null,
+        null,
+        new Date(),
+        OfferStatus.ENABLE,
+        10,
+        offerType,
+        [],
+        mockSeller,
+        productId,
+    );
+  }
+
+  beforeEach(() => {
+    product = new Product(
+      1,
+      'Test Product',
+      'description',
+      [],
+      'new',
+      true,
+      new Date(),
+      'active',
+      0,
+      [],
+      [],
+      [],
+      undefined,
+      undefined
+    );
+  });
+
+  it('should be defined', () => {
+    expect(product).toBeDefined();
+  });
+
+  describe('getBestOffer', () => {
+    it('should return the best offer if it exists', () => {
+      const bestOffer = offerFactory(1, OfferType.BEST_PRICE, 100);
+      product.bestOffer = bestOffer;
+      expect(product.getBestOffer()).toEqual(bestOffer);
+    });
+
+    it('should throw OfferNotFoundException if there is no best offer', () => {
+      product.bestOffer = undefined;
+      expect(() => product.getBestOffer()).toThrow(OfferNotFoundException);
+    });
+  });
+
+  describe('calculateReviewScore', () => {
+    it('should calculate the review score correctly', () => {
+      const reviews = [
+        new Review(1, 4, 'review 1', new Date(), [], 1),
+        new Review(2, 5, 'review 2', new Date(), [], 1),
+      ];
+      product.reviews.push(...reviews);
+      product.calculateReviewScore();
+      expect(product.reviewScore).toBe(4.5);
+    });
+
+    it('should return 0 if there are no reviews', () => {
+      product.calculateReviewScore();
+      expect(product.reviewScore).toBe(0);
+    });
+  });
+});

--- a/tests/unit/domain/services/offer.service.spec.ts
+++ b/tests/unit/domain/services/offer.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OfferService } from 'src/domain/services/offer.service';
+import { IOfferRepository } from 'src/application/ports/offer.repository.interface';
+import { TOKENS } from 'src/application/tokens';
+import { Offer } from 'src/domain/models/offer/offer';
+import { OfferType } from 'src/domain/enums/offer-type';
+import { OfferNotFoundException } from 'src/domain/exceptions/OfferNotFoundException';
+import { Price } from 'src/domain/models/price';
+import { OfferStatus } from 'src/domain/enums/offer-status';
+import { Seller } from 'src/domain/models/offer/seller';
+
+describe('OfferService', () => {
+  let service: OfferService;
+  let repository: IOfferRepository;
+
+  const mockOfferRepository = {
+    findByProductIdAndOfferTypes: jest.fn(),
+    findBy: jest.fn(),
+    findBestPriceOfferByProductId: jest.fn(),
+  };
+
+  const mockSeller = new Seller(1, 'Test Seller', 5, true);
+
+  const offerFactory = (productId: number, offerType: OfferType, amount: number) => {
+    const price = new Price('USD', amount);
+    return new Offer(
+        price,
+        price,
+        null,
+        null,
+        null,
+        new Date(),
+        OfferStatus.ENABLE,
+        10,
+        offerType,
+        [],
+        mockSeller,
+        productId,
+    );
+  }
+
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OfferService,
+        {
+          provide: TOKENS.OfferRepository,
+          useValue: mockOfferRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<OfferService>(OfferService);
+    repository = module.get<IOfferRepository>(TOKENS.OfferRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getOffersByProductIdAndOfferTypes', () => {
+    it('should return offers for a given product id and offer types', async () => {
+      const productId = 1;
+      const offerTypes = [OfferType.BEST_PRICE, OfferType.BEST_INSTALLMENTS];
+      const offers = [
+        offerFactory(productId, OfferType.BEST_PRICE, 100),
+      ];
+      mockOfferRepository.findByProductIdAndOfferTypes.mockResolvedValue(offers);
+
+      const result = await service.getOffersByProductIdAndOfferTypes(productId, offerTypes);
+
+      expect(result).toEqual(offers);
+      expect(repository.findByProductIdAndOfferTypes).toHaveBeenCalledWith(productId, offerTypes);
+    });
+
+    it('should throw OfferNotFoundException when no offers are found', async () => {
+      const productId = 1;
+      const offerTypes = [OfferType.BEST_PRICE];
+      mockOfferRepository.findByProductIdAndOfferTypes.mockResolvedValue([]);
+
+      await expect(service.getOffersByProductIdAndOfferTypes(productId, offerTypes)).rejects.toThrow(OfferNotFoundException);
+    });
+
+    it('should return a limited number of offers when limit is provided', async () => {
+        const productId = 1;
+        const offerTypes = [OfferType.BEST_PRICE, OfferType.BEST_INSTALLMENTS];
+        const offers = [
+            offerFactory(productId, OfferType.BEST_PRICE, 100),
+            offerFactory(productId, OfferType.BEST_INSTALLMENTS, 120),
+        ];
+        mockOfferRepository.findByProductIdAndOfferTypes.mockResolvedValue(offers);
+
+        const result = await service.getOffersByProductIdAndOfferTypes(productId, offerTypes, 1);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual(offers[0]);
+      });
+  });
+
+  describe('getAllOffersByProductId', () => {
+    it('should return all offers for a given product id', async () => {
+      const productId = 1;
+      const offers = [
+        offerFactory(productId, OfferType.BEST_PRICE, 100),
+      ];
+      mockOfferRepository.findBy.mockResolvedValue(offers);
+
+      const result = await service.getAllOffersByProductId(productId);
+
+      expect(result).toEqual(offers);
+      expect(repository.findBy).toHaveBeenCalledWith({ productId });
+    });
+
+    it('should throw OfferNotFoundException when no offers are found', async () => {
+      const productId = 1;
+      mockOfferRepository.findBy.mockResolvedValue([]);
+
+      await expect(service.getAllOffersByProductId(productId)).rejects.toThrow(OfferNotFoundException);
+    });
+
+    it('should return a limited number of offers when limit is provided', async () => {
+        const productId = 1;
+        const offers = [
+            offerFactory(productId, OfferType.BEST_PRICE, 100),
+            offerFactory(productId, OfferType.BEST_INSTALLMENTS, 120),
+        ];
+        mockOfferRepository.findBy.mockResolvedValue(offers);
+
+        const result = await service.getAllOffersByProductId(productId, 1);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual(offers[0]);
+      });
+  });
+
+  describe('getBestPricedOfferByProductId', () => {
+    it('should return the best priced offer for a given product id', async () => {
+      const productId = 1;
+      const bestOffer = offerFactory(productId, OfferType.BEST_PRICE, 80);
+      mockOfferRepository.findBestPriceOfferByProductId.mockResolvedValue(bestOffer);
+
+      const result = await service.getBestPricedOfferByProductId(productId);
+
+      expect(result).toEqual(bestOffer);
+      expect(repository.findBestPriceOfferByProductId).toHaveBeenCalledWith(productId);
+    });
+
+    it('should throw OfferNotFoundException when no offer is found', async () => {
+      const productId = 1;
+      mockOfferRepository.findBestPriceOfferByProductId.mockResolvedValue(null);
+
+      await expect(service.getBestPricedOfferByProductId(productId)).rejects.toThrow(OfferNotFoundException);
+    });
+  });
+});

--- a/tests/unit/domain/services/product.service.spec.ts
+++ b/tests/unit/domain/services/product.service.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductService } from 'src/domain/services/product.service';
+import { IProductRepository } from 'src/application/ports/product.repository.interface';
+import { TOKENS } from 'src/application/tokens';
+import { Product } from 'src/domain/models/product/product';
+import { ProductCategory } from 'src/domain/models/product/product-category';
+import { Category } from 'src/domain/models/category';
+import { ProductNotFoundException } from 'src/domain/exceptions/ProductNotFoundException';
+
+describe('ProductService', () => {
+  let service: ProductService;
+  let repository: IProductRepository;
+
+  const mockProductRepository = {
+    findProductById: jest.fn(),
+    findProductsByCategoriesIdAndLimit: jest.fn(),
+  };
+
+  const productFactory = (id: number, name: string) => {
+    return new Product(
+      id,
+      name,
+      'description',
+      [],
+      'new',
+      true,
+      new Date(),
+      'active',
+      5,
+      [],
+      [],
+      [],
+      undefined,
+      undefined
+    );
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductService,
+        {
+          provide: TOKENS.ProductRepository,
+          useValue: mockProductRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProductService>(ProductService);
+    repository = module.get<IProductRepository>(TOKENS.ProductRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getProductById', () => {
+    it('should return a product for a given id', async () => {
+      const productId = 1;
+      const product = productFactory(productId, 'Test Product');
+      mockProductRepository.findProductById.mockResolvedValue(product);
+
+      const result = await service.getProductById(productId);
+
+      expect(result).toEqual(product);
+      expect(repository.findProductById).toHaveBeenCalledWith(productId);
+    });
+
+    it('should throw ProductNotFoundException when no product is found', async () => {
+      const productId = 1;
+      mockProductRepository.findProductById.mockResolvedValue(null);
+
+      await expect(service.getProductById(productId)).rejects.toThrow(ProductNotFoundException);
+    });
+  });
+
+  describe('getRelatedProductsByCategoriesAndLimit', () => {
+    it('should return related products', async () => {
+      const category = new Category(1, 'Test Category', null);
+      const productCategory = new ProductCategory(1, category, 1, true);
+      const productCategories = [productCategory];
+      const productIdToExclude = 1;
+      const limit = 5;
+      const relatedProducts = [
+        productFactory(2, 'Related Product 1'),
+        productFactory(3, 'Related Product 2'),
+      ];
+      mockProductRepository.findProductsByCategoriesIdAndLimit.mockResolvedValue(relatedProducts);
+
+      const result = await service.getRelatedProductsByCategoriesAndLimit(productCategories, productIdToExclude, limit);
+
+      expect(result).toEqual(relatedProducts);
+      expect(repository.findProductsByCategoriesIdAndLimit).toHaveBeenCalledWith([category.id], productIdToExclude, limit);
+    });
+  });
+});

--- a/tests/unit/domain/services/review.service.spec.ts
+++ b/tests/unit/domain/services/review.service.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReviewService } from 'src/domain/services/review.service';
+import { IReviewRepository } from 'src/application/ports/review.repository.interface.ts';
+import { TOKENS } from 'src/application/tokens';
+import { Review } from 'src/domain/models/review/review';
+
+describe('ReviewService', () => {
+  let service: ReviewService;
+  let repository: IReviewRepository;
+
+  const mockReviewRepository = {
+    findBy: jest.fn(),
+  };
+
+  const reviewFactory = (id: number, productId: number) => {
+    return new Review(
+      id,
+      5,
+      'Test review',
+      new Date(),
+      [],
+      productId
+    );
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReviewService,
+        {
+          provide: TOKENS.ReviewRepository,
+          useValue: mockReviewRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReviewService>(ReviewService);
+    repository = module.get<IReviewRepository>(TOKENS.ReviewRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getReviewsByProductId', () => {
+    it('should return reviews for a given product id', async () => {
+      const productId = 1;
+      const reviews = [
+        reviewFactory(1, productId),
+        reviewFactory(2, productId),
+      ];
+      mockReviewRepository.findBy.mockResolvedValue(reviews);
+
+      const result = await service.getReviewsByProductId(productId);
+
+      expect(result).toEqual(reviews);
+      expect(repository.findBy).toHaveBeenCalledWith({ productId });
+    });
+
+    it('should return an empty array when no reviews are found', async () => {
+        const productId = 1;
+        mockReviewRepository.findBy.mockResolvedValue([]);
+
+        const result = await service.getReviewsByProductId(productId);
+
+        expect(result).toEqual([]);
+        expect(repository.findBy).toHaveBeenCalledWith({ productId });
+      });
+  });
+});


### PR DESCRIPTION
This commit adds unit tests for the following parts of the application:
- Domain services: `OfferService`, `ProductService`, and `ReviewService`.
- Application use cases: `OfferUseCases`, `ProductUseCases`, and `ReviewUseCases`.
- Domain models: `Offer` and `Product`.

The tests cover all the business logic in these files. The tests are written using Jest and the NestJS testing utilities. All tests are passing.