### PR TITLE
This commit introduces Swagger (OpenAPI) documentation to the NestJS …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/microservices": "^11.1.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "amqp-connection-manager": "^4.1.14",
         "amqplib": "^0.10.8",
@@ -23,6 +24,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "sqlite3": "^5.1.7",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
@@ -1948,6 +1950,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.4.tgz",
@@ -2581,6 +2589,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/microservices": {
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.5.tgz",
@@ -2756,6 +2784,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2937,6 +2998,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -5054,7 +5122,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -9443,7 +9510,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -15203,6 +15269,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.1.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
     "amqp-connection-manager": "^4.1.14",
     "amqplib": "^0.10.8",
@@ -35,6 +36,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.25"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { LoggerInterceptor } from './infrastructure/rest/logger.interceptor';
 import { ValidationPipe } from '@nestjs/common';
 import { HttpExceptionFilter } from './infrastructure/rest/http-exception.filter';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -14,6 +15,14 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
+
+  const config = new DocumentBuilder()
+    .setTitle('E-commerce API')
+    .setDescription('The E-commerce API description')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
 
   app.useGlobalInterceptors(new LoggerInterceptor());
   app.useGlobalFilters(new HttpExceptionFilter());

--- a/src/presentation/controllers/offer.controller.ts
+++ b/src/presentation/controllers/offer.controller.ts
@@ -2,14 +2,19 @@ import { Controller, Get, Param, Query } from '@nestjs/common';
 import { PositiveIntPipe } from '../common/pipes/positive-int.pipe';
 import { OfferUseCases } from 'src/application/use-cases/offer.use-cases';
 import { OfferVM } from '../view-models/offer/offer.vm';
-import { OfferType } from 'src/domain/enums/offer-type';
 import { OfferFilterVM } from '../view-models/offer/offer-filter.vm';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('offers')
 @Controller()
 export class OfferController {
     constructor(private readonly offerUseCases: OfferUseCases) {}
 
     @Get('products/:id/offers')
+    @ApiOperation({ summary: 'Get offers for a product' })
+    @ApiParam({ name: 'id', required: true, description: 'The ID of the product', type: Number })
+    @ApiResponse({ status: 200, description: 'A list of offers for the product.', type: [OfferVM] })
+    @ApiResponse({ status: 404, description: 'Product with the given ID not found.' })
     async getProductOffersByType(
         @Param('id', PositiveIntPipe) productId: number,
         @Query() filter: OfferFilterVM

--- a/src/presentation/controllers/product.controller.ts
+++ b/src/presentation/controllers/product.controller.ts
@@ -3,17 +3,29 @@ import { ProductUseCases } from 'src/application/use-cases/product.use-cases';
 import { GetProductVM } from '../view-models/product/get-product.vm';
 import { PositiveIntPipe } from '../common/pipes/positive-int.pipe';
 import { GetPreviewProductVM } from '../view-models/preview-product/get-preview-product.vm';
+import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('products')
 @Controller('products')
 export class ProductController {
     constructor(private readonly productUseCases: ProductUseCases) {}
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a product by its unique ID' })
+  @ApiParam({ name: 'id', required: true, description: 'The ID of the product', type: Number })
+  @ApiResponse({ status: 200, description: 'The requested product.', type: GetProductVM })
+  @ApiResponse({ status: 404, description: 'Product with the given ID not found.' })
   async getProductById(@Param('id', PositiveIntPipe) id: number): Promise<GetProductVM> {
     const product = await this.productUseCases.getProductById(id);
     return new GetProductVM(product);
   }
 
   @Get(':id/related')
+  @ApiOperation({ summary: 'Get related products for a given product' })
+  @ApiParam({ name: 'id', required: true, description: 'The ID of the product', type: Number })
+  @ApiQuery({ name: 'limit', required: false, description: 'The maximum number of related products to return', type: Number })
+  @ApiResponse({ status: 200, description: 'A list of related products.', type: [GetPreviewProductVM] })
+  @ApiResponse({ status: 404, description: 'Product with the given ID not found.' })
   async getRelatedProductsByProductId(
     @Param('id', PositiveIntPipe) id: number,
     @Query('limit') limit: number = 5

--- a/src/presentation/controllers/review.controller.ts
+++ b/src/presentation/controllers/review.controller.ts
@@ -2,12 +2,18 @@ import { Controller, Get, Param } from '@nestjs/common';
 import { ReviewVM } from '../view-models/review/review.vm';
 import { ReviewUseCases } from 'src/application/use-cases/review.use-cases';
 import { PositiveIntPipe } from '../common/pipes/positive-int.pipe';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('reviews')
 @Controller()
 export class ReviewController {
   constructor(private readonly reviewUseCases: ReviewUseCases) {}
 
   @Get('products/:id/reviews')
+  @ApiOperation({ summary: 'Get reviews for a product' })
+  @ApiParam({ name: 'id', required: true, description: 'The ID of the product', type: Number })
+  @ApiResponse({ status: 200, description: 'A list of reviews for the product.', type: [ReviewVM] })
+  @ApiResponse({ status: 404, description: 'Product with the given ID not found.' })
   async getReviewsByProduct(@Param('id', PositiveIntPipe) id: number): Promise<ReviewVM[]> {
     const reviews = await this.reviewUseCases.getReviewsByProductId(id);
     return reviews.map((r) => new ReviewVM(r));

--- a/src/presentation/view-models/common/installment-plan.vm.ts
+++ b/src/presentation/view-models/common/installment-plan.vm.ts
@@ -1,8 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { InstallmentPlan } from 'src/domain/models/offer/installment-plan';
 import { PriceVM } from './price.vm';
 
 export class InstallmentPlanVM {
+  @ApiProperty({ example: 12, description: 'The number of installments' })
   readonly installmentsCount: number;
+
+  @ApiProperty({ type: () => PriceVM, description: 'The amount of each installment' })
   readonly installmentAmount: PriceVM;
 
   constructor(installmentPlan: InstallmentPlan) {

--- a/src/presentation/view-models/common/price.vm.ts
+++ b/src/presentation/view-models/common/price.vm.ts
@@ -1,7 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Price } from "src/domain/models/price";
 
 export class PriceVM {
+  @ApiProperty({ example: 'USD', description: 'The currency of the price' })
   currency: string;
+
+  @ApiProperty({ example: 999.99, description: 'The amount of the price' })
   amount: number;
 
   constructor(price: Price) {

--- a/src/presentation/view-models/common/seller.vm.ts
+++ b/src/presentation/view-models/common/seller.vm.ts
@@ -1,8 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Seller } from "src/domain/models/offer/seller";
 
 export class SellerVM {
+  @ApiProperty({ example: 'BestSellers Inc.', description: 'The name of the seller' })
   name: string;
+
+  @ApiProperty({ example: 4.8, description: 'The score of the seller' })
   score: number;
+
+  @ApiProperty({ example: true, description: 'Indicates if the seller is verified' })
   isVerified: boolean;
 
   constructor(seller: Seller) {

--- a/src/presentation/view-models/offer/offer-filter.vm.ts
+++ b/src/presentation/view-models/offer/offer-filter.vm.ts
@@ -1,14 +1,27 @@
 import { IsOptional, IsArray, IsEnum, IsNumber, IsPositive } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { OfferType } from 'src/domain/enums/offer-type';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class OfferFilterVM {
+    @ApiProperty({
+        description: 'A comma-separated list of offer types to filter by',
+        required: false,
+        type: String,
+        example: 'Flash,Hot'
+    })
     @IsOptional()
     @IsArray()
     @IsEnum(OfferType, { each: true })
     @Transform(({ value }) => value.split(','))
     offerTypes?: OfferType[];
 
+    @ApiProperty({
+        description: 'The maximum number of offers to return',
+        required: false,
+        type: Number,
+        example: 10
+    })
     @IsOptional()
     @IsPositive()
     limit?: number = 5;

--- a/src/presentation/view-models/offer/offer.vm.ts
+++ b/src/presentation/view-models/offer/offer.vm.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { InstallmentPlanVM } from "../common/installment-plan.vm";
 import { PriceVM } from "../common/price.vm";
 import { SellerVM } from "../common/seller.vm";
@@ -5,14 +6,31 @@ import { ShipmentVM } from "./shipment.vm";
 import { Offer } from "src/domain/models/offer/offer";
 
 export class OfferVM {
+  @ApiProperty({ type: () => PriceVM, description: 'The base price of the offer' })
   readonly basePrice: PriceVM;
+
+  @ApiProperty({ type: () => PriceVM, description: 'The price without taxes' })
   readonly priceWithoutTaxes: PriceVM;
+
+  @ApiProperty({ type: () => InstallmentPlanVM, nullable: true, description: 'The installment plan for the offer' })
   readonly installmentPlan: InstallmentPlanVM | null;
+
+  @ApiProperty({ type: () => [ShipmentVM], description: 'The shipment options for the offer' })
   readonly shipments: ShipmentVM[];
+
+  @ApiProperty({ example: '2023-05-18T10:00:00Z', description: 'The date of the offer' })
   readonly date: Date;
+
+  @ApiProperty({ example: 'Active', description: 'The status of the offer' })
   readonly status: string;
+
+  @ApiProperty({ example: 100, description: 'The available stock for the offer' })
   readonly availableStock: number;
+
+  @ApiProperty({ example: 'Flash', nullable: true, description: 'The type of the offer' })
   readonly offerType: string | null;
+
+  @ApiProperty({ type: () => SellerVM, description: 'The seller of the offer' })
   readonly seller: SellerVM;
 
   constructor(offer: Offer) {

--- a/src/presentation/view-models/offer/shipment.vm.ts
+++ b/src/presentation/view-models/offer/shipment.vm.ts
@@ -1,9 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Price } from "src/domain/models/price";
 import { PriceVM } from "../common/price.vm";
 
 export class ShipmentVM {
+  @ApiProperty({ example: 'Express', description: 'The type of the shipment' })
   readonly type: string;
+
+  @ApiProperty({ example: '24 hours', description: 'The delivery time for the shipment' })
   readonly deliveryTime: string;
+
+  @ApiProperty({ type: () => PriceVM, description: 'The cost of the shipment' })
   readonly cost: PriceVM;
 
   constructor(type: string, deliveryTime: string, cost: Price) {

--- a/src/presentation/view-models/preview-product/get-preview-product.vm.ts
+++ b/src/presentation/view-models/preview-product/get-preview-product.vm.ts
@@ -1,12 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Product } from "src/domain/models/product/product";
 import { InstallmentPlanVM } from "../common/installment-plan.vm";
 import { PriceVM } from "../common/price.vm";
 
 export class GetPreviewProductVM {
+    @ApiProperty({ example: 'Apple iPhone 13 Pro', description: 'The name of the product' })
     name: string;
+
+    @ApiProperty({ type: () => PriceVM, description: 'The original price of the product' })
     originalPrice: PriceVM;
+
     //discountedPrice: PriceVM;
+
+    @ApiProperty({ type: () => InstallmentPlanVM, required: false, description: 'The installment plan for the product' })
     priceWithInstallments?: InstallmentPlanVM;
+
+    @ApiProperty({ example: true, description: 'Indicates if the product has free shipping' })
     isFreeShipping: boolean;
 
     constructor(product: Product) {

--- a/src/presentation/view-models/product/category.vm.ts
+++ b/src/presentation/view-models/product/category.vm.ts
@@ -1,7 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Category } from "src/domain/models/category";
 
 export class CategoryVM {
+  @ApiProperty({ example: 'Electronics', description: 'The name of the category' })
   name: string;
+
+  @ApiProperty({ example: 1, description: 'The ID of the parent category', required: false })
   parent?: number;
 
   constructor(category: Category) {

--- a/src/presentation/view-models/product/get-product.vm.ts
+++ b/src/presentation/view-models/product/get-product.vm.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Product } from "src/domain/models/product/product";
 import { ProductCategoryVM } from "./product-category.vm";
 import { SpecificationGroupVM } from "./specification-group.vm";
@@ -5,17 +6,39 @@ import { SellerVM } from "../common/seller.vm";
 import { ProductPhotoVM } from "./product.photo.vm";
 
 export class GetProductVM {
+  @ApiProperty({ example: 'Apple iPhone 13 Pro', description: 'The name of the product' })
   name: string;
+
+  @ApiProperty({ example: 'The latest iPhone model with a stunning ProMotion display.', description: 'A brief description of the product' })
   description: string;
+
+  @ApiProperty({ example: 'New', description: 'The condition of the product' })
   condition: string;
+
+  @ApiProperty({ example: true, description: 'Indicates if the product is returnable' })
   isReturnable: boolean;
+
+  @ApiProperty({ example: '2023-05-18T10:00:00Z', description: 'The date the product was created' })
   creationDate: string;
+
+  @ApiProperty({ example: '1 year', description: 'The warranty information for the product' })
   warranty: string;
+
+  @ApiProperty({ example: 'Active', description: 'The status of the product' })
   status: string;
+
+  @ApiProperty({ example: 4.5, description: 'The average review score for the product' })
   reviewScore: number;
+
+  @ApiProperty({ type: () => [SpecificationGroupVM], description: 'The specification groups for the product' })
   specificationGroups: SpecificationGroupVM[];
+
+  @ApiProperty({ type: () => [ProductCategoryVM], description: 'The categories the product belongs to' })
   categories: ProductCategoryVM[];
+
   //seller: SellerVM;
+
+  @ApiProperty({ type: () => [ProductPhotoVM], description: 'The photos of the product' })
   photos: ProductPhotoVM[];
 
   constructor(product: Product) {

--- a/src/presentation/view-models/product/product-category.vm.ts
+++ b/src/presentation/view-models/product/product-category.vm.ts
@@ -1,8 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { ProductCategory } from 'src/domain/models/product/product-category';
 import { CategoryVM } from './category.vm';
 
 export class ProductCategoryVM {
+  @ApiProperty({ example: 1, description: 'The ranking of the category for the product' })
   ranking: number;
+
+  @ApiProperty({ type: () => CategoryVM, description: 'The category details' })
   category: CategoryVM;
 
   constructor(pc: ProductCategory) {

--- a/src/presentation/view-models/product/product.photo.vm.ts
+++ b/src/presentation/view-models/product/product.photo.vm.ts
@@ -1,6 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { ProductPhoto } from "src/domain/models/product/product-photo";
 
 export class ProductPhotoVM {
+  @ApiProperty({ example: 'https://example.com/photo.jpg', description: 'The URL of the product photo' })
   url: string;
 
   constructor(photo: ProductPhoto) {

--- a/src/presentation/view-models/product/specification-group.vm.ts
+++ b/src/presentation/view-models/product/specification-group.vm.ts
@@ -1,8 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { SpecificationGroup } from "src/domain/models/specifications/specification-group";
 
 export class SpecificationGroupVM {
+  @ApiProperty({ example: 'General', description: 'The title of the specification group' })
   title: string;
+
+  @ApiProperty({ example: 'text', description: 'The type of specification' })
   specificationType: string;
+
+  @ApiProperty({ isArray: true, description: 'The items in the specification group' })
   items: any[];
 
   constructor(group: SpecificationGroup) {

--- a/src/presentation/view-models/review/review.photo.vm.ts
+++ b/src/presentation/view-models/review/review.photo.vm.ts
@@ -1,6 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { ReviewPhoto } from "src/domain/models/review/review-photo";
 
 export class ReviewPhotoVM {
+  @ApiProperty({ example: 'https://example.com/review-photo.jpg', description: 'The URL of the review photo' })
   url: string;
 
   constructor(photo: ReviewPhoto) {

--- a/src/presentation/view-models/review/review.vm.ts
+++ b/src/presentation/view-models/review/review.vm.ts
@@ -1,10 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Review } from "src/domain/models/review/review";
 import { ReviewPhotoVM } from "./review.photo.vm";
 
 export class ReviewVM {
+  @ApiProperty({ example: 5, description: 'The score of the review' })
   score: number;
+
+  @ApiProperty({ example: 'This is a great product!', description: 'The description of the review' })
   description: string;
+
+  @ApiProperty({ example: '2023-05-18T10:00:00Z', description: 'The date of the review' })
   date: string;
+
+  @ApiProperty({ type: () => [ReviewPhotoVM], description: 'The photos of the review' })
   photos: ReviewPhotoVM[];
 
   constructor(review: Review) {


### PR DESCRIPTION
…application.

- Adds `@nestjs/swagger` and `swagger-ui-express` dependencies.
- Configures Swagger in `src/main.ts` to generate and serve the API documentation at the `/api` endpoint.
- Annotates all existing controllers (`ProductController`, `OfferController`, `ReviewController`) and their respective endpoints with `@ApiOperation`, `@ApiParam`, `@ApiQuery`, and `@ApiResponse` decorators.
- Adds `@ApiProperty` decorators to all View Models (VMs/DTOs) to provide detailed schema information for API requests and responses.

This provides a comprehensive and interactive API documentation, making it easier for developers to understand and test the available endpoints.