### PR TITLE
feat: Add end-to-end tests for all endpoints

### DIFF
--- a/src/presentation/view-models/offer/offer-filter.vm.ts
+++ b/src/presentation/view-models/offer/offer-filter.vm.ts
@@ -11,5 +11,6 @@ export class OfferFilterVM {
 
     @IsOptional()
     @IsPositive()
+    @Transform(({ value }) => parseInt(value, 10))
     limit?: number = 5;
 }

--- a/src/presentation/view-models/product/get-product.vm.ts
+++ b/src/presentation/view-models/product/get-product.vm.ts
@@ -5,6 +5,7 @@ import { SellerVM } from "../common/seller.vm";
 import { ProductPhotoVM } from "./product.photo.vm";
 
 export class GetProductVM {
+  id: number;
   name: string;
   description: string;
   condition: string;
@@ -19,6 +20,7 @@ export class GetProductVM {
   photos: ProductPhotoVM[];
 
   constructor(product: Product) {
+    this.id = product.id;
     this.name = product.name;
     this.description = product.description;
     this.condition = product.condition;

--- a/tests/e2e/jest.d.ts
+++ b/tests/e2e/jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+    interface Matchers<R> {
+        toBeOneOf(items: any[]): R;
+    }
+}

--- a/tests/e2e/offer.e2e-spec.ts
+++ b/tests/e2e/offer.e2e-spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { TestAppModule } from './test.app.module';
+import { OfferType } from 'src/domain/enums/offer-type';
+
+describe('OfferController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestAppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new (require('src/infrastructure/rest/http-exception.filter').HttpExceptionFilter)());
+    app.useGlobalPipes(new (require('@nestjs/common').ValidationPipe)({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+    }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('/products/:id/offers (GET)', () => {
+    it('should return offers for a valid product id', () => {
+      const productId = 1;
+      return request(app.getHttpServer())
+        .get(`/products/${productId}/offers`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toBeInstanceOf(Array);
+        });
+    });
+
+    it('should filter offers by type', () => {
+        const productId = 1;
+        const offerType = OfferType.BEST_PRICE;
+        return request(app.getHttpServer())
+          .get(`/products/${productId}/offers?offerTypes=${offerType}`)
+          .expect(200)
+          .expect((res) => {
+            expect(res.body).toBeInstanceOf(Array);
+            res.body.forEach(offer => {
+                expect(offer.offerType).toBe(offerType);
+            });
+          });
+    });
+
+    it('should accept a limit query param', () => {
+        const productId = 1;
+        const limit = 1;
+        return request(app.getHttpServer())
+            .get(`/products/${productId}/offers?limit=${limit}`)
+            .expect(200)
+            .expect((res) => {
+                expect(res.body).toBeInstanceOf(Array);
+                expect(res.body.length).toBeLessThanOrEqual(limit);
+            });
+    });
+  });
+});

--- a/tests/e2e/product.e2e-spec.ts
+++ b/tests/e2e/product.e2e-spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { TestAppModule } from './test.app.module';
+
+describe('ProductController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestAppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new (require('src/infrastructure/rest/http-exception.filter').HttpExceptionFilter)());
+    app.useGlobalPipes(new (require('@nestjs/common').ValidationPipe)({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+    }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('/products/:id (GET)', () => {
+    it('should return a product for a valid id', () => {
+      const productId = 1;
+      return request(app.getHttpServer())
+        .get(`/products/${productId}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toBeDefined();
+          expect(res.body.id).toBe(productId);
+        });
+    });
+
+    it('should return 400 for an invalid id', () => {
+        return request(app.getHttpServer())
+          .get('/products/invalid-id')
+          .expect(400);
+    });
+
+    it('should return 404 for a non-existing product', () => {
+        const productId = 9999;
+        return request(app.getHttpServer())
+          .get(`/products/${productId}`)
+          .expect(404);
+    });
+  });
+
+  describe('/products/:id/related (GET)', () => {
+    it('should return 200 or 404, and an array if 200', () => {
+        const productId = 1;
+        return request(app.getHttpServer())
+          .get(`/products/${productId}/related`)
+          .expect((res) => {
+            expect(res.status).toBeOneOf([200, 404]);
+            if (res.status === 200) {
+              expect(res.body).toBeInstanceOf(Array);
+            }
+          });
+    });
+
+    it('should accept a limit query param', () => {
+        const productId = 1;
+        const limit = 1;
+        return request(app.getHttpServer())
+          .get(`/products/${productId}/related?limit=${limit}`)
+          .expect((res) => {
+            expect(res.status).toBeOneOf([200, 404]);
+            if (res.status === 200) {
+                expect(res.body).toBeInstanceOf(Array);
+                expect(res.body.length).toBeLessThanOrEqual(limit);
+            }
+          });
+    });
+  });
+});
+
+// Helper to extend jest's expect
+expect.extend({
+    toBeOneOf(received, items) {
+      const pass = items.includes(received);
+      if (pass) {
+        return {
+          message: () => `expected ${received} not to be one of [${items.join(', ')}]`,
+          pass: true,
+        };
+      } else {
+        return {
+          message: () => `expected ${received} to be one of [${items.join(', ')}]`,
+          pass: false,
+        };
+      }
+    },
+  });

--- a/tests/e2e/review.e2e-spec.ts
+++ b/tests/e2e/review.e2e-spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { TestAppModule } from './test.app.module';
+
+describe('ReviewController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestAppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new (require('src/infrastructure/rest/http-exception.filter').HttpExceptionFilter)());
+    app.useGlobalPipes(new (require('@nestjs/common').ValidationPipe)({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+    }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('/products/:id/reviews (GET)', () => {
+    it('should return reviews for a valid product id', () => {
+      const productId = 1;
+      return request(app.getHttpServer())
+        .get(`/products/${productId}/reviews`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toBeInstanceOf(Array);
+        });
+    });
+
+    it('should return an empty array for a product with no reviews', () => {
+        const productId = 5; // Product 5 has no reviews
+        return request(app.getHttpServer())
+          .get(`/products/${productId}/reviews`)
+          .expect(200)
+          .expect((res) => {
+            expect(res.body).toBeInstanceOf(Array);
+            expect(res.body.length).toBe(0);
+          });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
This commit introduces a suite of end-to-end (e2e) tests that cover all the available endpoints in the application. The tests are organized by controller, as requested.

Changes in this commit:
- Added e2e tests for `ProductController` endpoints (`/products/:id`, `/products/:id/related`).
- Added e2e tests for `OfferController` endpoints (`/products/:id/offers`).
- Added e2e tests for `ReviewController` endpoints (`/products/:id/reviews`).
- Improved the e2e test setup by adding a global exception filter and a validation pipe to the test application, making it more consistent with the production environment.
- Added a TypeScript declaration file (`jest.d.ts`) to support a custom Jest matcher, improving test readability.
- Fixed a bug in `GetProductVM` where the `id` field was missing.
- Fixed a validation issue in `OfferFilterVM` by adding a `@Transform` decorator to the `limit` property.

All unit and e2e tests are passing.